### PR TITLE
change append behavior of signalRemovePLI

### DIFF
--- a/src/spikeSort/spikeDetection.m
+++ b/src/spikeSort/spikeDetection.m
@@ -21,6 +21,7 @@ if nargin < 7
 end
 
 saveXfDetect = false;
+clearRemovePLI = true;
 
 makeOutputPath(cscFiles, outputPath, skipExist);
 nSegments = length(timestampFiles);
@@ -69,7 +70,7 @@ parfor i = 1: size(cscFiles, 1)
             continue
         end
 
-        signal = readCSC(channelFiles{j}, runRemovePLI, true, runCAR);
+        signal = readCSC(channelFiles{j}, runRemovePLI, clearRemovePLI, runCAR);
         if isempty(signal)
             warning(sprintf('spikeDetection: error reading file: \n%s \n', channelFiles{j}));
             continue;

--- a/src/utils/readCSC.m
+++ b/src/utils/readCSC.m
@@ -32,6 +32,10 @@ if runRemovePLI && ismember('signalRemovePLI', who('-file', filename)) && ~isemp
     % up with runCAR.
     signal = matObj.signalRemovePLI;
     runRemovePLI = false;
+    if clearRemovePLI
+        matObj = matfile(filename, 'Writable', true);
+        matObj.signalRemovePLI = [];
+    end
 elseif ismember('ADBitVolts', who('-file', filename)) && ~isnan(matObj.ADBitVolts)
     signal = single(signal(:)) * matObj.ADBitVolts * 1e6; % convert signal to micro volt
 elseif ismember('BlackRockUnits', who('-file', filename))
@@ -64,19 +68,15 @@ else
     end
 end
 
-if clearRemovePLI
-    matObj = matfile(filename, 'Writable', true);
-    matObj.signalRemovePLI = [];
-end
-
 if runRemovePLI
     fprintf("run removePLI on: %s\n", filename);
     tic
     signalRemovePLI = removePLI(double(signal), 1/samplingIntervalSeconds, numel(60:60:3060), [50 .2 1], [.1 4 1], 2, 60);
     toc
     signalRemovePLI = single(signalRemovePLI(:));
-    matObj = matfile(filename, 'Writable', true);
+    
     if ~clearRemovePLI
+        matObj = matfile(filename, 'Writable', true);
         matObj.signalRemovePLI = signalRemovePLI;
     end
     signal = signalRemovePLI;


### PR DESCRIPTION
Pre edit:
Line 72 in spikeDetection.m calls `signal = readCSC(channelFiles{j}, runRemovePLI, true, runCAR);` The 3rd var "true" is clearRemovePLI - this is hardcoded so default behavior before edit was to add an empty signalRemovePLI vector to every unpacked micro mat file, regardless of whether removePLI was run. Even if removePLI is run, it is saved to the mat file and then immediately cleared.

Post edit:
This edit retains the possibility of saving signalRemovePLI in micro mat files (if clearRemovePLI is set to false in spikeDetection), but is still hardcoded to not.

Now if removePLI=1 (and this has NOT been run before) and clearRemovePLI=1, signalRemovePLI is just not saved to the mat file.

If removePLI=1 (and this HAS been run before) and clearRemovePLI=1, signalRemovePLI is loaded from the mat and then set to an empty vector.

If removePLI=0 no empty signalRemovePLI is appended to the micro mat file.