### PR TITLE
Handle BlackRock unpacking with missing headstages and properly unpack BR TTLs

### DIFF
--- a/scripts/run_unpackBlackRock.m
+++ b/scripts/run_unpackBlackRock.m
@@ -22,10 +22,10 @@ montageConfigFile =  'montage_Patient-581_exp-2_2025-05-29_14-49-24.json'; %'/Us
 %%% end run parameters %%%
 
 
-
 %% BR data extraction
 
 outFilePath = ['/Users/sldunn/HoffmanMount/data/PIPELINE_vc/ANALYSIS/' exp_name '/' pID '_' exp_name];
+
 
 % montageConfigFile = [];
 [renameMacroChannels, renameMicroChannels] = createBRChannels(montageConfigFile);
@@ -41,8 +41,8 @@ for i = 1: length(filePath)
         continue
     end
     inFile = fullfile(filePath{i}, eventFile.name);
-    outputFile = fullfile(expFilePath, "CSC_events/Events_001.mat");
-    unpackBlackRockEvent(inFile, outputFile, skipExist);
+    eventsOutputFile = fullfile(expFilePath, "CSC_events/Events_001.mat");
+    digitalTTLsFound = unpackBlackRockEvent(inFile, eventsOutputFile, skipExist);
     disp('unpack event finished!')
 
     if unpack_micro
@@ -57,6 +57,7 @@ for i = 1: length(filePath)
             unpackBlackRock(inFile, expFilePath, renameMicroChannels, skipExist);
             disp([microFile(j).name ': unpack micro channels finished!'])
         end
+
     end
 
     if unpack_analogue
@@ -70,6 +71,12 @@ for i = 1: length(filePath)
             inFile = fullfile(filePath{i}, microFile(j).name);
             unpackBlackRock(inFile, expFilePath, analogue_channels, skipExist);
             disp([microFile(j).name ': unpack analogue channels finished!'])
+        end
+        
+        if ~digitalTTLsFound
+            disp("Since no digital events were found, attempting to load TTLs from ainp1");
+            ainpFilepath = fullfile(expFilePath, "CSC_micro/ainp1_001.mat");
+            unpackBlackRockAnalogEvent(ainpFilepath, eventsOutputFile);
         end
     end
 

--- a/scripts/run_unpackBlackRock.m
+++ b/scripts/run_unpackBlackRock.m
@@ -1,22 +1,34 @@
 % unpack the macro and micro blackrock data.
 
-% define filePath, experiment id and outFilePath here or comment it will trigger a UI to
-% select paths and experiment id:
 clear
 scriptDir = fileparts(mfilename('fullpath'));
 addpath(genpath(fileparts(scriptDir)));
 
+%%% define run parameters %%%
 skipExist = 1;
-expIds = 1;
+pID = '581';
+exp_name = 'MovieParadigm'; % Screening
+expIds = 4;
+unpack_micro = 1;
+unpack_macro = 1;
+unpack_analogue = 1; 
+analogue_channels = {'ainp1', 'ainp2'};
 filePath = {...
-    '/Volumes/DATA/BRData/SubjectData/570/EXP1_Screening/20240124-152841',...
+    '/Volumes/DATA/BRData/SubjectData/581/EXP4_Movie_24_Pre_Sleep/20250211-092357',...
+    % % '/Volumes/DATA/BRData/SubjectData/581/EXP5_Movie_24_Sleep/20250211-193335',... 
     };
+montageConfigFile =  'montage_Patient-581_exp-2_2025-05-29_14-49-24.json'; %'/Users/sldunn/HoffmanMount/data/PIPELINE_vc/ANALYSIS/Screening/570_Screening/Experiment-1/montage_Patient-570_exp-1_2025-04-22_17-14-27.json'; 
 
-outFilePath = '/Users/sldunn/HoffmanMount/data/PIPELINE_vc/ANALYSIS/Screening/570_Screening';
-montageConfigFile = '/Users/sldunn/HoffmanMount/data/PIPELINE_vc/ANALYSIS/Screening/570_Screening/Experiment-1/montage_Patient-570_exp-1_2025-04-22_17-14-27.json';
+%%% end run parameters %%%
+
+
+
+%% BR data extraction
+
+outFilePath = ['/Users/sldunn/HoffmanMount/data/PIPELINE_vc/ANALYSIS/' exp_name '/' pID '_' exp_name];
 
 % montageConfigFile = [];
-[renameMacroChannels, renameMicroChannels] = createChannels(montageConfigFile);
+[renameMacroChannels, renameMicroChannels] = createBRChannels(montageConfigFile);
 
 for i = 1: length(filePath)
 
@@ -24,8 +36,8 @@ for i = 1: length(filePath)
 
     % unpack event file:
     eventFile = dir(fullfile(filePath{i}, '*.nev'));
-    if length(eventFile) > 1 || isempty(eventFile)
-        warning('zero or multiple .nev files detected!\n unpack event for %s is skipped.', filePath{i});
+    if isempty(eventFile)
+        warning('zero .nev files detected!\n unpack event for %s is skipped.', filePath{i});
         continue
     end
     inFile = fullfile(filePath{i}, eventFile.name);
@@ -33,26 +45,107 @@ for i = 1: length(filePath)
     unpackBlackRockEvent(inFile, outputFile, skipExist);
     disp('unpack event finished!')
 
-    % unpack micro channels:
-    microFile = dir(fullfile(filePath{i}, '*.ns5'));
-    if length(microFile) > 1 || isempty(microFile)
-        warning('zero or multiple .ns5 files detected!\n unpack micro for %s is skipped.', filePath{i});
-        continue
+    if unpack_micro
+        % unpack micro channels:
+        microFile = dir(fullfile(filePath{i}, '*.ns5'));
+        if isempty(microFile)
+            warning('zero .ns5 files detected!\n unpack micro for %s is skipped.', filePath{i});
+            continue
+        end
+        for j = 1:length(microFile)
+            inFile = fullfile(filePath{i}, microFile(j).name);
+            unpackBlackRock(inFile, expFilePath, renameMicroChannels, skipExist);
+            disp([microFile(j).name ': unpack micro channels finished!'])
+        end
     end
 
-    inFile = fullfile(filePath{i}, microFile.name);
-    unpackBlackRock(inFile, expFilePath, renameMicroChannels, skipExist);
-    disp('unpack micro channels finished!')
-
-    % unpack macro channels:
-    macroFile = dir(fullfile(filePath{i}, '*.ns3'));
-    if length(macroFile) > 1 || isempty(macroFile)
-        warning('zero or multiple .ns3 files detected!\n unpack macro for %s is skipped.', filePath{i});
-        continue
+    if unpack_analogue
+        % unpack analogue microphone channels
+        microFile = dir(fullfile(filePath{i}, '*.ns5'));
+        if isempty(microFile)
+            warning('zero .ns5 files detected!\n unpack analogue for %s is skipped.', filePath{i});
+            continue
+        end
+        for j = 1:length(microFile)
+            inFile = fullfile(filePath{i}, microFile(j).name);
+            unpackBlackRock(inFile, expFilePath, analogue_channels, skipExist);
+            disp([microFile(j).name ': unpack analogue channels finished!'])
+        end
     end
 
-    inFile = fullfile(filePath{i}, macroFile.name);
-    % unpackBlackRock(inFile, expFilePath, renameMacroChannels, skipExist);
-    disp('unpack macro channels finished!')
+    if unpack_macro
+        % unpack macro channels:
+        macroFile = dir(fullfile(filePath{i}, '*.ns3'));
+        if isempty(macroFile)
+            warning('zero .ns3 files detected!\n unpack macro for %s is skipped.', filePath{i});
+            continue
+        end
+        for j = 1:length(macroFile)
+            inFile = fullfile(filePath{i}, macroFile(j).name);
+            unpackBlackRock(inFile, expFilePath, renameMacroChannels, skipExist);
+            disp([macroFile(j).name ': unpack macro channels finished!'])
+        end
+    end
+end
+% EOS
 
+
+
+%% subfunc
+function [macroChannels, microChannels] = createBRChannels(montageConfigFile)
+% read montage json file and save macro and micro channel names as cell
+% arrays. 
+% For micro this is in the format: G[A-D][1-4]_{area}[1-8]
+% For macro: {area}[1-total_number_of_channels] 
+%                  (i.e. the clinical montage channel number)
+
+
+if isempty(montageConfigFile)
+    [macroChannels, microChannels] = deal([]);
+    return
+end
+
+montageConfig = readJson(montageConfigFile);
+Data = loadMacroChannels(montageConfig.macroChannels);
+
+labels = Data(:,1);
+starts = cell2mat(Data(:,2));
+ends   = cell2mat(Data(:,3));
+% pre‑allocate
+total = sum(ends - starts + 1);
+macroChannels = cell(total,1);
+idx = 1;
+for i = 1:numel(labels)
+    for v = starts(i):ends(i)
+        macroChannels{idx} = sprintf('%s%d', labels{i}, v);
+        idx = idx + 1;
+    end
+end
+%macroChannels = {};
+% for i = 1: size(Data, 1)
+%     numChannels = Data{i, 3} - Data{i, 2} + 1;
+%     startIdx = Data{i, 2};
+%     for j = 1: numChannels
+%         macroChannels(startIdx+j-1) = {[Data{i, 1}, num2str(j)]};
+%     end
+% end
+% macroChannels = macroChannels(:);
+
+microChannels = {};
+microConfig = montageConfig.Headstages;
+headStages = fieldnames(microConfig);
+for i = 1: length(headStages)
+    ports = fieldnames(microConfig.(headStages{i}));
+    for j = 1: length(ports)
+        channel = microConfig.(headStages{i}).(ports{j});
+        numChannel = channel.Micros;
+        brainLabel = channel.BrainLabel;
+        if strcmp(brainLabel, '')
+            channels = cell(1, numChannel);
+        else
+            channels = arrayfun(@(idx) [headStages{i}, num2str(j), '-', brainLabel, num2str(idx)], 1: numChannel, 'UniformOutput', false);
+        end
+        microChannels = [microChannels; channels(:)];
+    end
+end
 end

--- a/scripts/run_unpackBlackRock.m
+++ b/scripts/run_unpackBlackRock.m
@@ -7,13 +7,13 @@ scriptDir = fileparts(mfilename('fullpath'));
 addpath(genpath(fileparts(scriptDir)));
 
 skipExist = 1;
-expIds = 2;
+expIds = 1;
 filePath = {...
-    '/Volumes/DATA/BRData/SubjectData/581/EXP2_Movie24_Control_Vid/20250210-162916',...
+    '/Volumes/DATA/BRData/SubjectData/570/EXP1_Screening/20240124-152841',...
     };
 
-outFilePath = '/Users/XinNiuAdmin/HoffmanMount/data/PIPELINE_vc/ANALYSIS/MovieParadigm/581_MovieParadigm/';
-montageConfigFile = '/Volumes/DATA/BRData/SubjectData/581/montage_Patient-581_exp-1_2025-02-10_11-08-16.json';
+outFilePath = '/Users/sldunn/HoffmanMount/data/PIPELINE_vc/ANALYSIS/Screening/570_Screening';
+montageConfigFile = '/Users/sldunn/HoffmanMount/data/PIPELINE_vc/ANALYSIS/Screening/570_Screening/Experiment-1/montage_Patient-570_exp-1_2025-04-22_17-14-27.json';
 
 % montageConfigFile = [];
 [renameMacroChannels, renameMicroChannels] = createChannels(montageConfigFile);

--- a/src/BlackRockIO/blackrock_read_channel.m
+++ b/src/BlackRockIO/blackrock_read_channel.m
@@ -3,14 +3,21 @@ function outFiles = blackrock_read_channel(inFile, electrodeInfoFile, skipExist,
 % Blackrock data is saved in a single file containing all channels. We use
 % openNSx.m to read each channel for the .ns3/.ns5/.ns6 file and save data
 % separately.
+%
 % The NSx header contains bank, port, and channel number info.
 % When a montage is generated and channelNames are passed through 
-% we use this info to match the BR channel to the correct channelNames
+% we use this info to match the BR channel to the correct channelNames 
 % entry.
-% If no channelNames passed through default chan filename is used
-% G[A-D][1-4]-elec{electrode_number}_001.mat 
-% ("_001" to be consistent with NLX)
-
+% If no channelNames passed through default chan filename is used (ie the
+% label in the header table + rec num)
+% Can also pass analogue input channels in through channelNames (eg
+% {'ainp1','ainp2'} to extract those directly
+%
+% This code assumes that the micros are always in channels 1 to 128 and the
+% macros are 129 to 256, and that these neural channels will always be the
+% first rows in any given nsX file. If this is not the case there may be a
+% mismatch in file names when a montage is input
+%
 
 if nargin < 3 || isempty(skipExist)
     skipExist = 0;
@@ -20,82 +27,80 @@ if nargin < 4 || isempty(channelNames)
     channelNames = [];
 end
 
-outputFilePath = fileparts(electrodeInfoFile);
-electrodeInfoObj = matfile(electrodeInfoFile);
-NSx = electrodeInfoObj.NSx;
-channelId = NSx.MetaTags.ChannelID;
-% channelIdx = channelId <= 256;
-neuralChannelIdx = channelId <= 256;
-% auxChannelIdx = channelID > 256; % this is true for micro, not sure about macro? do we want separate aux extraction? how does NLX code do it?
-
-neural_electrodes_info = NSx.ElectrodesInfo(neuralChannelIdx);
-
-n_channels = length(neural_electrodes_info);
-connector_banks = [1, 2, 3, 4];
-bank_mapping = {'A','B','C', 'D'};
-outFiles = cell(n_channels,1);
-matched_channels = cell(n_channels,1); % store to compare if any chans in names not matched
-
-% loop over neural channels and generate output file name
-for n=1:n_channels
-
-    % read bank and connector pin info from table
-    bank_num = neural_electrodes_info(n).ConnectorBank;
-    bank = bank_mapping{connector_banks==bank_num};
-
-    connector_pin = double(neural_electrodes_info(n).ConnectorPin);
-
-    % figure out your port and channel number
-    port_num = ceil(connector_pin/8); % will return value between 1 and 4
-    channel_num = connector_pin - (8 * (port_num - 1)); % returns value 1-8
-
-    % generate a default file name for cases of no channelNames passed or no matches found.
-    default_chan_name = ['G' bank num2str(port_num) '-elec' num2str(neural_electrodes_info(n).ChannelID) '_001.mat'];
-
-    % if channelNames have been passed through
-    if ~isempty(channelNames)
-
-        % generate a regex pattern and search through the channel names for a match
-        channel_pattern = ['G' bank num2str(port_num) '-(.*?)' num2str(channel_num)];
-
-        chan_name_match = false(length(channelNames),1);
-        for k=1:length(channelNames)     
-              match = regexp(channelNames{k}, channel_pattern,'once');
-              if match==1
-                  chan_name_match(k) = match;
-              end
-        end
-        matched_chan = channelNames(chan_name_match);
-
-        if isempty(matched_chan) % if no match found, use default fn
-            outFiles{n} = fullfile(outputFilePath,default_chan_name);
-            disp(['Despite passing channel names have not found a match, defaulting filename to: ' outFiles{n}])
-        elseif length(matched_chan)>1 % if more than one match break run
-            disp(['More than 1 channel matches for ' channel_pattern '- check your montage!!'])
-            return
-        elseif length(matched_chan)==1 % if one match, use to generate output file name
-            outFiles{n} = fullfile(outputFilePath, [matched_chan{1} '_001.mat']);
-            matched_channels{n} = char(matched_chan{1});
-        end
-    else % no channel names passed through, use default fn     
-        outFiles{n} = fullfile(outputFilePath,default_chan_name);
-    end
-
+% determine if neural or analogue unpacking
+if contains(channelNames,'ainp')
+    unpack_type = 'analogue';
+else
+    unpack_type = 'neural';
 end
 
-% remove empty cells 
-matched_channels(cellfun(@(x)isempty(x),matched_channels),:)=[];
-missing_chan_idx = ~ismember(channelNames,matched_channels);
-% this info is reported after extraction loop below
+% determine if macro or micro based on file type
+[~, ~, ext] = fileparts(inFile);
+if strcmp(ext,'.ns5')
+    data_type = 'micro';
+elseif strcmp(ext, '.ns3')
+    data_type = 'macro';
+end
+
+% determine rec number 
+tokens = regexp(inFile, '-(\d{3})\.[^.]+$', 'tokens');
+if ~isempty(tokens)
+    rec_num = tokens{1}{1};
+else
+    rec_num = '001';
+end
+
+% get header info
+outputFilePath = fileparts(electrodeInfoFile);
+electrodeInfoObj = load(electrodeInfoFile);
+electrode_table = struct2table(electrodeInfoObj.NSx.ElectrodesInfo);
+
+%% select electrodes (neural or analogue) and create appropriate file paths
+% outFiles is the output file path for each nsx_chan that will be read from
+%   the data file
+% nsx_chans is the indices for each channel in the data file 
+% also returns any missing channel names (from montage or rec)
+if isempty(channelNames) % no channels passed just extract all
+    labels = cellfun(@(s) regexp(s, '[A-Za-z0-9]+', 'match', 'once'), electrode_table.Label, 'UniformOutput', false);
+    outFiles = fullfile(outputFilePath,labels);  
+    outFiles = strcat(outFiles,['_' rec_num]);
+    outFiles = strcat(outFiles, '.mat');  
+    nsx_chans = 1:height(electrode_table);
+    channel_in_montage_but_not_rec = [];
+    channel_in_rec_but_not_montage = [];
+    pattern = '*';
+else
+    switch unpack_type
+        case 'neural'
+            neural_electrode_table = electrode_table(electrode_table.ChannelID <= 256,:);
+            switch data_type
+                case 'micro'
+                    [outFiles, nsx_chans,channel_in_montage_but_not_rec,channel_in_rec_but_not_montage] = create_micro_filenames(channelNames,outputFilePath, rec_num,neural_electrode_table);
+                    pattern = 'G[A-D][1-4]-(.*?)[1-8]';
+                case 'macro'
+                    [outFiles, nsx_chans,channel_in_montage_but_not_rec,channel_in_rec_but_not_montage] = create_macro_filenames(channelNames,outputFilePath, rec_num,neural_electrode_table);
+                    pattern = '[A-Za-z]-(.*?)[1-10]';
+            end
+            
+        case 'analogue'
+            [outFiles, nsx_chans,channel_in_montage_but_not_rec,channel_in_rec_but_not_montage] = create_analogue_filenames(channelNames,outputFilePath, rec_num,electrode_table);
+            pattern = 'ainp';
+    end
+end
+
 
 % save outFile names to csv
 writecell(outFiles(:), fullfile(fileparts(outFiles{1}), 'outFileNames.csv'));
 
-nchan = length(outFiles);
-pattern = 'G[A-D][1-4]-(.*?)[1-9]';
-
-% extract data on each chan
-parfor i = 1: nchan
+% extract ouside parfor to prevent overhead warning
+channelIDs = electrode_table.ChannelID;
+bank = electrode_table.ConnectorBank;
+pin = electrode_table.ConnectorPin;
+resolution = electrode_table.Resolution;
+units = electrode_table.AnalogUnits;
+units = cellfun(@(s) regexp(s, '[A-Za-z0-9]+', 'match', 'once'), units, 'UniformOutput', false);
+%% extract data on each chan
+parfor i = nsx_chans
     if skipExist && exist(outFiles{i}, 'file')
         fprintf('skip existing file: %s\n', outFiles{i});
         continue
@@ -108,7 +113,7 @@ parfor i = 1: nchan
 
     % skip micro channel with empty channel name:
     match = regexp(outFile, pattern, 'tokens', 'once');
-
+ 
     if ~isempty(match)
         if isempty(match{1}) || strcmp(match{1}, '''''') || strcmp(match{1}, '''') || strcmp(match{1}, ' ') || strcmp(match{1}, '""') || strcmp(match{1}, '" "')
             warning('skip empty channel: %s', outFiles{i});
@@ -137,17 +142,255 @@ parfor i = 1: nchan
     outFileObj = matfile(tmpOutFile);
     outFileObj.data = data;
     outFileObj.samplingInterval = samplingInterval;
-    outFileObj.samplingIntervalSeconds = seconds(samplingInterval);
-    outFileObj.BlackRockUnits = 1/4;
+    %outFileObj.samplingIntervalSeconds = seconds(samplingInterval);
+    outFileObj.BlackRockUnits = resolution(i);
+    outFileObj.ChannelID = channelIDs(i);
+    outFileObj.ConnectorBank = bank(i);
+    outFileObj.ConnectorPin = pin(i);
+    outFileObj.UnitsAfterConv = units{i};
     movefile(tmpOutFile, outFiles{i});
 end
 
-% report if any channel names passed through have not been matched
-if sum(missing_chan_idx)>0
-    fprintf('\nWARNING!!\n"The following channels were passed to be extracted but have not been matched with the BR data:\n"')
-    disp(channelNames(missing_chan_idx))
+
+% report (and log) channels in montage but not recorded
+if ~isempty(channel_in_montage_but_not_rec)
+    fprintf('\n\nWARNING!!!\n\nThe following channels were in the montage but have not been matched with the BR data:\n');
+    disp(channel_in_montage_but_not_rec);
+    write_missing_channels( ...
+        channel_in_montage_but_not_rec, ...
+        outputFilePath, ...
+        ['channels_in_montage_but_not_rec__' unpack_type '.txt'], ...
+        'Channels in montage but not found in data:' );
 end
 
-fprintf('\nDone.\n');
+% report (and log) channels recorded but not in montage
+if ~isempty(channel_in_rec_but_not_montage)
+    fprintf('\n\nWARNING!!\n\nThe following channels were recorded but have not been matched with a channel in the montage:\n');
+    disp(channel_in_rec_but_not_montage);
+    write_missing_channels( ...
+        channel_in_rec_but_not_montage, ...
+        outputFilePath, ...
+        ['channels_in_rec_but_not_montage__' unpack_type '.txt'], ...
+        'Channels recorded in data but are not in montage:' );
+end
 
 end
+% EOF
+
+
+
+
+
+
+
+%% subfuncs
+function [outFiles,nsx_chans,channel_in_montage_but_not_rec,channel_in_rec_but_not_montage] = create_micro_filenames(channelNames,outputFilePath, rec_num,electrode_table)
+
+n_channels = height(electrode_table);
+connector_banks = [1, 2, 3, 4, 9]; % 9 is analogue input bank
+bank_mapping = {'A','B','C', 'D','X'};
+outFiles = cell(n_channels,1);
+labels = cellfun(@(s) regexp(s, '[A-Za-z0-9]+', 'match', 'once'), electrode_table.Label, 'UniformOutput', false);
+% for logging missing channels
+matched_channels = cell(n_channels,1); % store to compare if any chans in names not matched
+channel_in_montage_but_not_rec = cell(n_channels,1);
+channel_in_rec_but_not_montage = cell(n_channels,1);
+
+for n=1:n_channels
+
+    % read bank and connector pin info from table
+    bank_num = electrode_table.ConnectorBank(n);
+    bank = bank_mapping{connector_banks==bank_num};
+
+    connector_pin = double(electrode_table.ConnectorPin(n));
+
+    % figure out your port and channel number
+    port_num = ceil(connector_pin/8); % will return value between 1 and 4
+    channel_num = connector_pin - (8 * (port_num - 1)); % returns value 1-8
+
+    % if channelNames have been passed through
+    if ~isempty(channelNames)
+
+        % generate a regex pattern and search through the channel names for a match
+        channel_pattern = ['G' bank num2str(port_num) '-(.*?)' num2str(channel_num)];
+
+        chan_name_match = false(length(channelNames),1);
+        for k=1:length(channelNames)
+            match = regexp(channelNames{k}, channel_pattern,'once');
+            if match==1
+                chan_name_match(k) = match;
+            end
+        end
+        matched_chan = channelNames(chan_name_match);
+
+        if isempty(matched_chan) % if no match found, use default fn
+            channel_in_rec_but_not_montage{n} =  labels{n};
+        elseif length(matched_chan)>1 % if more than one match break run
+            disp(['More than 1 channel matches montage for ' channel_pattern '- check your montage!!'])
+            return
+        elseif length(matched_chan)==1 % if one match, use to generate output file name
+            outFiles{n} = fullfile(outputFilePath, [matched_chan{1} '_' rec_num '.mat']);
+            matched_channels{n} = char(matched_chan{1});
+        end
+    else % no channel names found to match this channel, log here
+        channel_in_montage_but_not_rec{n} = labels{n};
+    end
+
+end
+
+% remove empty cells 
+matched_channels(cellfun(@(x)isempty(x),matched_channels),:)=[];
+channel_in_montage_but_not_rec = channelNames(~ismember(channelNames,matched_channels));
+channel_in_rec_but_not_montage(cellfun(@(x)isempty(x),channel_in_rec_but_not_montage),:)=[];
+% missing channel info is reported after extraction loop
+
+% neural data always comes first in files (I think!) ie chan 1-128 for micros
+nsx_chans = 1:n_channels;
+
+end
+% end create_micro_filenames
+
+function [outFiles, nsx_chans,channel_in_montage_but_not_rec,channel_in_rec_but_not_montage] = create_macro_filenames(channelNames,outputFilePath, rec_num,electrode_table)
+
+%% extract info from channelNames
+
+% probe names and channel numbers
+tokens = regexp(channelNames, '^([^\d]+)(\d+)$', 'tokens', 'once');
+N = numel(tokens);
+montage_channel_names = cell(N,1);
+montage_channel_nums = zeros(N,1);
+for i = 1:N
+    % tokens{i} is a 1×2 cell: { '<letters>', '<digits>' }
+    montage_channel_names{i} = tokens{i}{1};
+    montage_channel_nums(i) = str2double(tokens{i}{2});
+end
+
+% first electrode number for each probe
+[unique_names, ~, idx] = unique(montage_channel_names);
+min_probe_channel = cell(numel(unique_names),2);
+for k = 1:numel(unique_names)
+    mask = (idx == k);
+    min_probe_channel{k,1} = unique_names{k};
+    min_probe_channel{k,2} = min(montage_channel_nums(mask));
+end
+
+
+%% loop and generate file names
+n_channels = height(electrode_table);
+outFiles = cell(n_channels,1);
+% for logging missing channels
+labels = cellfun(@(s) regexp(s, '[A-Za-z0-9]+', 'match', 'once'), electrode_table.Label, 'UniformOutput', false);
+matched_channels = cell(n_channels,1); % store to compare if any chans in names not matched
+channel_in_montage_but_not_rec = cell(n_channels,1);
+channel_in_rec_but_not_montage = cell(n_channels,1);
+
+
+for n = 1:n_channels
+    
+    channelID = electrode_table.ChannelID(n) - 128; % because macro channels are always 129-256
+    % find the recorded channel number in the montage input
+    montage_match = montage_channel_nums == channelID;
+
+    if sum(montage_match)==0 % cannot find in montage, log here
+        channel_in_rec_but_not_montage{n} = labels{n};
+    elseif sum(montage_match) > 1 % more than one match, something must be wrong with montage
+        disp(['More than 1 channel matches montage for ' channelNames{n} '- check your montage!!'])
+        return
+    elseif sum(montage_match) == 1 % match found in montage
+        % get the electrode name
+        elec_name = montage_channel_names{montage_match}; 
+        % figure out channel num between 1 and n_total_on_probe
+        min_chan = min_probe_channel{strcmp(min_probe_channel(:,1),elec_name),2}; 
+        elec_num = channelID - min_chan + 1;
+
+        outFiles{n} = fullfile(outputFilePath,[elec_name num2str(elec_num) '_' rec_num '.mat']);
+
+        matched_channels{n} = channelNames{montage_match};
+    end
+end
+
+% remove empty cells 
+matched_channels(cellfun(@(x)isempty(x),matched_channels),:)=[];
+channel_in_montage_but_not_rec = channelNames(~ismember(channelNames,matched_channels));
+channel_in_rec_but_not_montage(cellfun(@(x)isempty(x),channel_in_rec_but_not_montage),:)=[];
+% missing channel info is reported after extraction loop
+
+% neural data always comes first in files (I think!) ie chan 129-256 for
+% macros, which is in rows 1-128 in header table
+nsx_chans = 1:n_channels;
+
+end
+% end create_macro_filenames
+
+
+function  [outFiles,nsx_chans,channel_in_montage_but_not_rec,channels_in_rec_but_not_montage] = create_analogue_filenames(channelNames,outputFilePath, rec_num,electrode_table)
+
+n_channels = length(electrode_table);
+outFiles = cell(n_channels,1);
+nsx_chans = NaN(1, n_channels);
+labels = cellfun(@(s) regexp(s, '[A-Za-z0-9]+', 'match', 'once'), electrode_table.Label, 'UniformOutput', false);
+% for logging missing channels
+matched_channels = cell(n_channels,1); % store to compare if any chans in names not matched
+channel_in_montage_but_not_rec = cell(n_channels,1);
+
+for n = 1:length(channelNames)
+     % find row in table
+    row_num = find(contains(electrode_table.Label,channelNames{n}));  
+    if isempty(row_num)
+        channel_in_montage_but_not_rec{n} = labels{row_num};
+    else
+        nsx_chans(n) = row_num;
+        matched_channels{n} = labels{row_num};
+        % generate filename
+        outFiles{n} = fullfile(outputFilePath,[channelNames{n} '_' rec_num '.mat']);
+    end
+end
+
+% remove empty elements
+matched_channels(cellfun(@(x)isempty(x),matched_channels)) = [];
+channel_in_montage_but_not_rec(cellfun(@(x)isempty(x),channel_in_montage_but_not_rec)) = [];
+
+% find all ainp channels that were recorded but not requested to extract
+ainp_labels = labels(electrode_table.ConnectorBank==9);
+channels_in_rec_but_not_montage =  ainp_labels(~ismember(ainp_labels,matched_channels));
+
+
+end
+% end create_analogue_filenames
+
+
+function write_missing_channels(chList, outputDir, fileName, headerText)
+% Writes out a text file listing channels, but only if chList is nonempty.
+%
+%   chList     = cell‑array of channel names
+%   outputDir  = folder to write into
+%   fileName   = name of the .txt file to create
+%   headerText = one‐line header for the file
+
+    if isempty(chList)
+        return
+    end
+
+    % ensure output folder exists
+    if ~exist(outputDir,'dir')
+        mkdir(outputDir);
+    end
+
+    fullPath = fullfile(outputDir, fileName);
+    fid = fopen(fullPath, 'w');
+    if fid == -1
+        error('Could not open log file "%s" for writing.', fullPath);
+    end
+
+    % write header
+    fprintf(fid, '%s\n\n', headerText);
+
+    % write each channel
+    for i = 1:numel(chList)
+        fprintf(fid, '%s\n', chList{i});
+    end
+
+    fclose(fid);
+    fprintf('Wrote missing‐channel log: %s\n', fullPath);
+end
+% end write_missing_channels

--- a/src/BlackRockIO/blackrock_read_channel.m
+++ b/src/BlackRockIO/blackrock_read_channel.m
@@ -106,6 +106,9 @@ parfor i = 1:length(nsx_chans)
         continue
     end
 
+    if isempty(outFiles{i})
+        continue
+    end
     [~, outFile] = fileparts(outFiles{i});
     if isempty(outFile)
         continue

--- a/src/utils/unpackBlackRockAnalogEvent.m
+++ b/src/utils/unpackBlackRockAnalogEvent.m
@@ -1,0 +1,34 @@
+function unpackBlackRockAnalogEvent(input_fname, output_fname)
+    ttlCode = [];
+    ts = [];
+    
+    load(input_fname);
+    
+    voltage_diff = diff(data);
+    threshold = 10000;
+    state = 0;
+    num_ttls = 0;
+    for i = 1:length(voltage_diff)
+        
+        if state == 0
+
+            if voltage_diff(i) >= threshold
+                num_ttls = num_ttls + 1;
+                ttlCode(num_ttls, 1) = 1;
+                ts(num_ttls, 1) = (i - 1) * seconds(samplingInterval);
+                state = 1;
+            end
+        else
+            if voltage_diff(i) <= (-1 * threshold)
+                state = 0;
+            end
+
+        end
+
+    end
+
+    outFileObj = matfile(output_fname, "Writable", true);
+    outFileObj.TTLs = ttlCode;
+    outFileObj.timestamps = ts;
+
+end

--- a/src/utils/unpackBlackRockAnalogEvent.m
+++ b/src/utils/unpackBlackRockAnalogEvent.m
@@ -1,3 +1,7 @@
+% Given an input unpacked analog mat file and an Events mat file, writes
+% detected event timestamps to the Events file. Note that Analog events are
+% just represented as rising edges in a square wave, so all TTL values are
+% set to 1.
 function unpackBlackRockAnalogEvent(input_fname, output_fname)
     ttlCode = [];
     ts = [];

--- a/src/utils/unpackBlackRockEvent.m
+++ b/src/utils/unpackBlackRockEvent.m
@@ -1,3 +1,10 @@
+% Given an input unpacked NEV mat file and an output Events mat file, write TTL
+% events from the NEV file to the output file. Note TTL number data is
+% originally in NEV.Data.SerialDigitalIO.UnparsedData, but we need to clean
+% erroneous event detection and 0 (reset) TTLs values before saving them to
+% the Events file. If no digital TTLs are found (in our Goldmin setup we send TTLs
+% to an analog channel) this function returns false and creates an Events
+% mat file with empty values for TTLs and timestamps
 function digitalEventsFound = unpackBlackRockEvent(inFile, outputFile, skipExist)
 
 digitalEventsFound = true;


### PR DESCRIPTION
Soraya noticed that in cases where headstages were "skipped" in the clinical montage, the Blackrock channels were not properly mapped in the data unpacking, as the recording channel names were just assigned sequentially to the recorded data (including headstages which should have been skipped). This PR fixes that issue by using Blackrock recording header data to correctly map recording channel names to their corresponding recorded data instead of simply relying on sequential order.

Furthermore, we noticed that no Blackrock unpacked Events files included any TTL data. Upon further investigation, I found an error in the TTL parsing logic which was removing all valid TTLs. Furthermore, I have added support for analog Event parsing, as our Goldmine-Blackrock set up currently sends Event data in analog format to the ainp1 channel.

Soraya has tested the unpacking code on an m1 mac, and I have tested the TTL unpacking code on an Ubuntu 22.04 machine.