### PR TITLE
Update Neuralynx unpacking to include AD Channel matching and Timestamp ordering

### DIFF
--- a/src/NlxIO/Nlx_getADChannel.m
+++ b/src/NlxIO/Nlx_getADChannel.m
@@ -1,0 +1,11 @@
+function ADChannel = Nlx_getADChannel(fileName)
+    ADChannel = -1;
+
+    fid = fopen(fileName, 'r');
+    raw = fread(fid, 16384, '*uchar')';
+    fclose(fid);
+    header = string(char(raw));
+    ADChannel = regexp(header,'(?<=ADChannel\s)[\d]+','match');
+    ADChannel = str2num(ADChannel{1});
+
+end

--- a/src/NlxIO/Nlx_getFirstTimestamp.m
+++ b/src/NlxIO/Nlx_getFirstTimestamp.m
@@ -1,0 +1,22 @@
+function startTimestamp = Nlx_getFirstTimestamp(fileName, isNev)
+    startTimestamp = uint64(0);
+    
+    skipBytes = 16384;
+    if nargin > 1 && isNev
+        skipBytes = skipBytes + 6;
+    end
+    
+    fid = fopen(fileName, 'r');
+    header = fread(fid, skipBytes, '*uchar');
+    raw = fread(fid, 8, '*uchar');
+    fclose(fid);
+    for rawIndex = 1:length(raw)
+        startTimestamp = bitsll(startTimestamp,8);
+        startTimestamp = startTimestamp + uint64(raw(length(raw) - rawIndex + 1));
+    end
+
+
+    
+    %startTimestamp = datetime(startTimestamp, 'ConvertFrom', 'posixtime');
+    
+end

--- a/src/NlxIO/getADChannelMap.m
+++ b/src/NlxIO/getADChannelMap.m
@@ -1,0 +1,76 @@
+function [macroChannelMap, microChannelMap] = getADChannelMap(montageConfigFile)
+
+    if isempty(montageConfigFile)
+        [macroChannelMap, microChannelMap]  = deal([]);
+        return;
+    end
+    
+    montageConfig = readJson(montageConfigFile);
+    macroChannelsList = {};
+    macroChannelsAD = [];
+    % handle macros
+    numMacrosAdded = 0;
+    for macroGroupIdx = 1: length(montageConfig.macroChannels)
+        currentMacroGroup = montageConfig.macroChannels(macroGroupIdx);
+        currentMacroGroup = currentMacroGroup{1, 1};
+        macroGroupName = currentMacroGroup{1, 1};
+        groupStartIdx = currentMacroGroup{2, 1};
+        groupEndIdx = currentMacroGroup{3, 1};
+        
+        for currentMacroIdx = groupStartIdx : groupEndIdx
+            currentMacroNumber = currentMacroIdx - groupStartIdx + 1;
+            %currentMacroName = macroGroupName + string(currentMacroNumber);
+            currentMacroName = {[macroGroupName, num2str(currentMacroNumber)]};
+            currentMacroADChannel = currentMacroIdx - 1;
+            numMacrosAdded = numMacrosAdded + 1;
+            
+            macroChannelsList(numMacrosAdded) = currentMacroName;
+            macroChannelsAD(numMacrosAdded) = currentMacroADChannel;
+    
+        end
+    
+    
+    
+    end
+    macroChannelMap = dictionary(macroChannelsAD, macroChannelsList);
+    
+    
+    % handle micros
+    microChannelsList = {};
+    microChannelsAD = [];
+    headStages = fieldnames(montageConfig.Headstages);
+    currentMicroAD = 128;
+    if isfield(montageConfig, 'MicroChannelStart')
+        currentMicroAD = montageConfig.MicroChannelStart;
+    end
+    numMicrosAdded = 0;
+    for headStageIdx  = 1 : length(headStages)
+        currentBankName = headStages{headStageIdx};
+        ports = fieldnames(montageConfig.Headstages.(currentBankName));
+        if isempty(ports)
+            currentMicroAD = currentMicroAD + 32;
+        end
+        for portIdx = 1 : length(ports)
+            currentPortName = ports{portIdx};
+            currentMicroBundleInfo = montageConfig.Headstages.(currentBankName).(currentPortName);
+            numMicrosInBundle = currentMicroBundleInfo.Micros;
+            microBundleName = currentMicroBundleInfo.BrainLabel;
+    
+            for microIdx = 1 : numMicrosInBundle
+                currentMicroName = {[currentBankName, num2str(portIdx), '-', microBundleName, num2str(microIdx)]};
+                currentMicroADChannel = currentMicroAD + (microIdx - 1);
+                numMicrosAdded = numMicrosAdded + 1;
+                microChannelsList(numMicrosAdded) = currentMicroName;
+                microChannelsAD(numMicrosAdded) = currentMicroADChannel;
+            end
+            currentMicroAD = currentMicroAD + 8;
+        end
+    
+        
+    
+    
+    end
+    
+    
+    microChannelMap = dictionary(microChannelsAD, microChannelsList);
+end

--- a/src/utils/config.m
+++ b/src/utils/config.m
@@ -9,6 +9,8 @@ IGNORE_FILES = {
     '^A2.*\.ncs';
     '^C3.*\.ncs';
     '^C4.*\.ncs';
+    '^F3.*\.ncs';
+    '^F4.*\.ncs';
     '^EMG.*\.ncs';
     '^EOG.*\.ncs';
     '^Analogue1.*\.ncs';

--- a/src/utils/createIOFiles.m
+++ b/src/utils/createIOFiles.m
@@ -42,7 +42,8 @@ if ~isempty(renameChannels)
     %todo: replace this with in-out matching based on AD Channel #
     channels = [];
     unmatchedInFileIndices = [];
-    for inFileIdx = 1 : length(inFileNames)
+    [numInFileGroups, ~] = size(inFileNames)
+    for inFileIdx = 1 : numInFileGroups
         currentInFilename = inFileNames{inFileIdx, 2};
         currentInFileAD = Nlx_getADChannel(currentInFilename);
         if isKey(renameChannels, currentInFileAD)
@@ -54,7 +55,7 @@ if ~isempty(renameChannels)
     
     end
     inFiles = inFileNames(:, 2:end);
-    inFiles(unmatchedInFileIndices) = [];
+    inFiles(unmatchedInFileIndices, :) = [];
 else
     channels = inFileNames(:, 1);
     inFiles = inFileNames(:, 2:end);

--- a/src/utils/createIOFiles.m
+++ b/src/utils/createIOFiles.m
@@ -39,13 +39,22 @@ formattedStrings = cellfun(formatString, inFileNames(:, 1), 'UniformOutput', fal
 inFileNames = inFileNames(sortOrder, :);
 
 if ~isempty(renameChannels)
-    if length(renameChannels) > size(inFileNames, 1)
-        warning('renamed channels longer than original channels')
-        renameChannels = renameChannels(1:size(inFileNames, 1));
+    %todo: replace this with in-out matching based on AD Channel #
+    channels = [];
+    unmatchedInFileIndices = [];
+    for inFileIdx = 1 : length(inFileNames)
+        currentInFilename = inFileNames{inFileIdx, 2};
+        currentInFileAD = Nlx_getADChannel(currentInFilename);
+        if isKey(renameChannels, currentInFileAD)
+            renameChannelName = renameChannels(currentInFileAD);
+            channels = [channels; renameChannelName];
+        else
+            unmatchedInFileIndices = [unmatchedInFileIndices; inFileIdx];
+        end
+    
     end
-    nonEmptyChannels = find(~cellfun(@isempty, renameChannels));
-    channels = renameChannels(nonEmptyChannels);
-    inFiles = inFileNames(nonEmptyChannels, 2:end);
+    inFiles = inFileNames(:, 2:end);
+    inFiles(unmatchedInFileIndices) = [];
 else
     channels = inFileNames(:, 1);
     inFiles = inFileNames(:, 2:end);

--- a/src/utils/groupFiles.m
+++ b/src/utils/groupFiles.m
@@ -117,7 +117,7 @@ eventFileNames = getNeuralynxFiles(inputPath, '.nev', ignoreFilesWithSizeBelow);
 eventFileNames = cellfun(@(x) fullfile(inputPath, x), eventFileNames, 'UniformOutput', false);
 if length(eventFileNames) > 1
     fprintf("groupFiles: order event files by create time. \n");
-    order = orderFilesByTime(eventFileNames);
+    order = orderFilesByTime(eventFileNames, 1);
     eventFileNames = eventFileNames(order);
 end
 
@@ -159,12 +159,14 @@ files = reshape(files, r, c);
 end
 
 
-function order = orderFilesByTime(files)
-
+function order = orderFilesByTime(files, isEvents)
+    if nargin < 2
+        isEvents = 0;
+    end
     startTimes = zeros(length(files), 1);
     for i = 1:length(files)
         if ~isempty(files{i})
-            startTimes(i) = Nlx_getFirstTimestamp(files{i});
+            startTimes(i) = Nlx_getFirstTimestamp(files{i}, isEvents);
         else
             startTimes(i) = intmax('uint64');
         end


### PR DESCRIPTION
Previously, when a montage file was passed to the unpack Neuralynx UI, input NCS files were just matched alphabetically against the NCS files specified in the montage. For micros this is generally fine, as the bank information at the beginning of the filenames lead to correct sortings. However, this is often not the case with macros, nor is it the case if there are jumps in the banks, meaning more often than not, specifying a montage file for Neuralynx unpacking would result in incorrectly matched unpacked mat files. By utilizing the AD Channel number specified both in the montage config and each NCS file's header as a matching key, we can accurately unpack data and even handle incorrectly labeled data by passing in a corrected montage file.

Furthermore, we noted that temporal ordering for multiple files was done by looking at the file creation time instead of the actual first timestamp listed in each file; I have changed it so that all file groups per channel are now sorted based on these timestamps, as things like accidentally modifying/touching a file or a misordering in file creation would potentially previously throw off correct unpacking ordering.

These changes were tested in 585's  multiple Screening unpackings (where each channel only had one non-blank recording file), as well as in 585's SleepStim unpacking (where each channel had multiple files).

Note: neither the previous pipeline nor this updated one can handle cases where the number of recording files per channel in the same recording group differ (e.g. LA1 has 3 files, LA2 has 4). As far as we know, this case will never occur unless a recording channel is added mid-session (which would be highly unusual). Nonetheless, I am working on a future update to handle this case, and this update does lay some of the foundations for allowing this.