### PR TITLE
Stimulation Artifact Removal during Spike Sorting

### DIFF
--- a/batch/batch_spikeSorting.m
+++ b/batch/batch_spikeSorting.m
@@ -1,4 +1,4 @@
-function batch_spikeSorting(workerId, totalWorkers, expIds, filePath, skipExist, runRemovePLI, runCAR, runSpikeReject)
+function batch_spikeSorting(workerId, totalWorkers, expIds, filePath, skipExist, runRemovePLI, runCAR, runSpikeReject, runStimulationArtifactRemoval, stimulationArtifactParams)
     % run spike detection and spike sorting to the unpacked data:
     % run can modify this script and run on different patients/exp when
     % at least one previous job is running (a temporary job script is created).
@@ -20,6 +20,11 @@ function batch_spikeSorting(workerId, totalWorkers, expIds, filePath, skipExist,
 
     if nargin < 7
         runCAR = false;
+    end
+
+    if nargin < 8
+        runStimulationArtifactRemoval = false;
+        stimulationArtifactParams = struct;
     end
 
     if ~exist('runSpikeReject', 'var')
@@ -64,10 +69,10 @@ function batch_spikeSorting(workerId, totalWorkers, expIds, filePath, skipExist,
     %% spike detection:
 
     expFilePath = [filePath, '/Experiment', sprintf('-%d', expIds)];
-    outputPath = fullfile(expFilePath, sprintf('CSC_micro_spikes_removePLI-%d_CAR-%d_rejectNoiseSpikes-%d', int8(runRemovePLI), int8(runCAR), int8(runSpikeReject)));
+    outputPath = fullfile(expFilePath, sprintf('CSC_micro_spikes_removePLI-%d_CAR-%d_rejectNoiseSpikes-%d_removeStimulationArtifacts-%d', int8(runRemovePLI), int8(runCAR), int8(runSpikeReject), int8(runStimulationArtifactRemoval)));
 
     fprintf('run spike detection in parallel on %d (out of %d) threads...\n', parJobs, maxNumCompThreads);
-    spikeFiles = spikeDetection(microFiles, timestampFiles, outputPath, expNames, skipExist(1), runRemovePLI, runCAR);
+    spikeFiles = spikeDetection(microFiles, timestampFiles, outputPath, expNames, skipExist(1), runRemovePLI, runCAR, runStimulationArtifactRemoval, stimulationArtifactParams);
     disp('Spike Detection Finished!')
 
     %% spike clustering:

--- a/batch/batch_spikeSorting.m
+++ b/batch/batch_spikeSorting.m
@@ -70,13 +70,16 @@ function batch_spikeSorting(workerId, totalWorkers, expIds, filePath, skipExist,
     %% spike detection:
 
     expFilePath = [filePath, '/Experiment', sprintf('-%d', expIds)];
-    outputPath = fullfile(expFilePath, sprintf('CSC_micro_spikes_removePLI-%d_CAR-%d_rejectNoiseSpikes-%d_removeStimulationArtifacts-%d', int8(runRemovePLI), int8(runCAR), int8(runSpikeReject), int8(runStimulationArtifactRemoval)));
+    outputPath = fullfile(expFilePath, sprintf('CSC_micro_spikes_removePLI-%d_CAR-%d_rejectNoiseSpikes-%d_removeStimArtifacts-%d', int8(runRemovePLI), int8(runCAR), int8(runSpikeReject), int8(runStimulationArtifactRemoval)));
+    if ~exist(outputPath,'dir'); mkdir(outputPath); end
 
     jsonStimParams = jsonencode(stimulationArtifactParams, PrettyPrint=true);
-    jsonStimFname = [outputPath, '/stim_artifact_removal_params.json'];
-    jsonStimFID = fopen(jsonStimFname,'w');
-    fprintf(jsonStimFID, jsonStimParams);
-    fclose(jsonStimFID);
+    jsonStimFname = fullfile(outputPath, 'stim_artifact_removal_params.json');
+    if ~exist(jsonStimFname,'file') % for when parallel jobs sent
+        jsonStimFID = fopen(jsonStimFname,'w');
+        fprintf(jsonStimFID, jsonStimParams);
+        fclose(jsonStimFID);
+    end
 
     fprintf('run spike detection in parallel on %d (out of %d) threads...\n', parJobs, maxNumCompThreads);
     spikeFiles = spikeDetection(microFiles, timestampFiles, outputPath, expNames, skipExist(1), runRemovePLI, runCAR, runStimulationArtifactRemoval, stimulationArtifactParams);

--- a/batch/batch_spikeSorting.m
+++ b/batch/batch_spikeSorting.m
@@ -26,6 +26,7 @@ function batch_spikeSorting(workerId, totalWorkers, expIds, filePath, skipExist,
         runStimulationArtifactRemoval = false;
         stimulationArtifactParams = struct;
     end
+    stimulationArtifactParams.runStimulationArtifactRemoval = runStimulationArtifactRemoval;
 
     if ~exist('runSpikeReject', 'var')
         runSpikeReject = true;
@@ -70,6 +71,12 @@ function batch_spikeSorting(workerId, totalWorkers, expIds, filePath, skipExist,
 
     expFilePath = [filePath, '/Experiment', sprintf('-%d', expIds)];
     outputPath = fullfile(expFilePath, sprintf('CSC_micro_spikes_removePLI-%d_CAR-%d_rejectNoiseSpikes-%d_removeStimulationArtifacts-%d', int8(runRemovePLI), int8(runCAR), int8(runSpikeReject), int8(runStimulationArtifactRemoval)));
+
+    jsonStimParams = jsonencode(stimulationArtifactParams, PrettyPrint=true);
+    jsonStimFname = [expFilePath, '/stim_artifact_removal_params.json'];
+    jsonStimFID = fopen(jsonStimFname,'w');
+    fprintf(jsonStimFID, jsonStimParams);
+    fclose(jsonStimFID);
 
     fprintf('run spike detection in parallel on %d (out of %d) threads...\n', parJobs, maxNumCompThreads);
     spikeFiles = spikeDetection(microFiles, timestampFiles, outputPath, expNames, skipExist(1), runRemovePLI, runCAR, runStimulationArtifactRemoval, stimulationArtifactParams);

--- a/batch/batch_spikeSorting.m
+++ b/batch/batch_spikeSorting.m
@@ -73,7 +73,7 @@ function batch_spikeSorting(workerId, totalWorkers, expIds, filePath, skipExist,
     outputPath = fullfile(expFilePath, sprintf('CSC_micro_spikes_removePLI-%d_CAR-%d_rejectNoiseSpikes-%d_removeStimulationArtifacts-%d', int8(runRemovePLI), int8(runCAR), int8(runSpikeReject), int8(runStimulationArtifactRemoval)));
 
     jsonStimParams = jsonencode(stimulationArtifactParams, PrettyPrint=true);
-    jsonStimFname = [expFilePath, '/stim_artifact_removal_params.json'];
+    jsonStimFname = [outputPath, '/stim_artifact_removal_params.json'];
     jsonStimFID = fopen(jsonStimFname,'w');
     fprintf(jsonStimFID, jsonStimParams);
     fclose(jsonStimFID);

--- a/batch/runbatch_job.sh
+++ b/batch/runbatch_job.sh
@@ -71,6 +71,7 @@ runStimulationArtifactRemoval="0"
 stimulationArtifactPreRemovalTimeSecs="0.05"
 stimulationArtifactPostRemovalTimeSecs="0.3"
 stimTTL="1";
+testStimTTL="32"
 
 # if expIds is updated, do not skipExist any steps so that threshold for spike detection is same across experiments
 skipExist="[0, 0, 0]"  # [spike detection, spike code, spike clustering]
@@ -116,6 +117,7 @@ matlab  -nosplash -nodisplay <<EOF
     stimulationArtifactParams.preRemovalTimeSecs = ${stimulationArtifactPreRemovalTimeSecs};
     stimulationArtifactParams.postRemovalTimeSecs = ${stimulationArtifactPostRemovalTimeSecs};
     stimulationArtifactParams.stimTTL = ${stimTTL};
+    stimulationArtifactParams.testStimTTL = ${testStimTTL};
     stimulationArtifactParams.eventsDir = fullfile([filePath, '/Experiment', sprintf('-%d', expIds), '/CSC_events']);
 
     maxNumCompThreads($maxThreads);

--- a/batch/runbatch_job.sh
+++ b/batch/runbatch_job.sh
@@ -68,6 +68,7 @@ runSpikeReject="1"
 
 # stimulation artifact rejection parameters
 runStimulationArtifactRemoval="0"
+stimulationArtifactStimulationExps = "[9]" 
 stimulationArtifactPreRemovalTimeSecs="0.05"
 stimulationArtifactPostRemovalTimeSecs="0.3"
 stimTTL="1";
@@ -114,11 +115,22 @@ matlab  -nosplash -nodisplay <<EOF
 
     runStimulationArtifactRemoval = ${runStimulationArtifactRemoval};
     stimulationArtifactParams = struct;
+    stimulationArtifactParams.stimulationExps = ${stimulationArtifactPreRemovalTimeSecs};
     stimulationArtifactParams.preRemovalTimeSecs = ${stimulationArtifactPreRemovalTimeSecs};
     stimulationArtifactParams.postRemovalTimeSecs = ${stimulationArtifactPostRemovalTimeSecs};
     stimulationArtifactParams.stimTTL = ${stimTTL};
     stimulationArtifactParams.testStimTTL = ${testStimTTL};
-    stimulationArtifactParams.eventsDir = fullfile([filePath, '/Experiment', sprintf('-%d', expIds), '/CSC_events']);
+    
+    if (runStimulationArtifactRemoval && isempty(stimulationArtifactParams.stimulationExps))
+        stimulationArtifactParams.stimulationExps = expIds;
+    end
+    stimulationArtifactParams.eventsDirs = {};
+    
+    for stimulationExpIdx =  1:length(stimulationArtifactParams.stimulationExps)
+        stimulationExpId = stimulationArtifactParams.stimulationExps(stimulationExpIdx);
+        stimExpEventsDir = fullfile([filePath, '/Experiment', sprintf('-%d', stimulationExpId), '/CSC_events']);
+        stimulationArtifactParams.eventsDirs{1, stimulationExpIdx} = stimExpEventsDir;
+    end
 
     maxNumCompThreads($maxThreads);
     if strcmp('${mode}', 'spikeSorting')

--- a/batch/runbatch_job.sh
+++ b/batch/runbatch_job.sh
@@ -71,7 +71,6 @@ runStimulationArtifactRemoval="0"
 stimulationArtifactPreRemovalTimeSecs="0.05"
 stimulationArtifactPostRemovalTimeSecs="0.3"
 stimTTL="1";
-stimulationArtifactParams.eventsDir = fullfile([filePath, '/Experiment', sprintf('-%d', expIds), '/CSC_events']);
 
 # if expIds is updated, do not skipExist any steps so that threshold for spike detection is same across experiments
 skipExist="[0, 0, 0]"  # [spike detection, spike code, spike clustering]

--- a/batch/runbatch_job.sh
+++ b/batch/runbatch_job.sh
@@ -72,7 +72,8 @@ stimulationArtifactStimulationExps = "[9]"
 stimulationArtifactPreRemovalTimeSecs="0.05"
 stimulationArtifactPostRemovalTimeSecs="0.3"
 stimTTL="1";
-testStimTTL="32"
+testStimTTL="32";
+stimulationArtifactSaveRemovedSignalSegments="2";
 
 # if expIds is updated, do not skipExist any steps so that threshold for spike detection is same across experiments
 skipExist="[0, 0, 0]"  # [spike detection, spike code, spike clustering]
@@ -120,6 +121,7 @@ matlab  -nosplash -nodisplay <<EOF
     stimulationArtifactParams.postRemovalTimeSecs = ${stimulationArtifactPostRemovalTimeSecs};
     stimulationArtifactParams.stimTTL = ${stimTTL};
     stimulationArtifactParams.testStimTTL = ${testStimTTL};
+    stimulationArtifactParams.saveRemovedSignalSegments = ${stimulationArtifactSaveRemovedSignalSegments}; 
     
     if (runStimulationArtifactRemoval && isempty(stimulationArtifactParams.stimulationExps))
         stimulationArtifactParams.stimulationExps = expIds;

--- a/batch/runbatch_job.sh
+++ b/batch/runbatch_job.sh
@@ -115,7 +115,7 @@ matlab  -nosplash -nodisplay <<EOF
 
     runStimulationArtifactRemoval = ${runStimulationArtifactRemoval};
     stimulationArtifactParams = struct;
-    stimulationArtifactParams.stimulationExps = ${stimulationArtifactPreRemovalTimeSecs};
+    stimulationArtifactParams.stimulationExps = ${stimulationArtifactStimulationExps};
     stimulationArtifactParams.preRemovalTimeSecs = ${stimulationArtifactPreRemovalTimeSecs};
     stimulationArtifactParams.postRemovalTimeSecs = ${stimulationArtifactPostRemovalTimeSecs};
     stimulationArtifactParams.stimTTL = ${stimTTL};

--- a/batch/runbatch_job.sh
+++ b/batch/runbatch_job.sh
@@ -65,6 +65,14 @@ expIds="[3]"
 runRemovePLI="0"
 runCAR="1"
 runSpikeReject="1"
+
+# stimulation artifact rejection parameters
+runStimulationArtifactRemoval="0"
+stimulationArtifactPreRemovalTimeSecs="0.05"
+stimulationArtifactPostRemovalTimeSecs="0.3"
+stimTTL="1";
+stimulationArtifactParams.eventsDir = fullfile([filePath, '/Experiment', sprintf('-%d', expIds), '/CSC_events']);
+
 # if expIds is updated, do not skipExist any steps so that threshold for spike detection is same across experiments
 skipExist="[0, 0, 0]"  # [spike detection, spike code, spike clustering]
 mode="spikeSorting"  # Change to "extractLFP" to run extractLFP
@@ -104,10 +112,17 @@ matlab  -nosplash -nodisplay <<EOF
     workingDir = getDirectory();
     filePath = fullfile(workingDir, '${expName}/${patientId}_${expName}');
 
+    runStimulationArtifactRemoval = ${runStimulationArtifactRemoval};
+    stimulationArtifactParams = struct;
+    stimulationArtifactParams.preRemovalTimeSecs = ${stimulationArtifactPreRemovalTimeSecs};
+    stimulationArtifactParams.postRemovalTimeSecs = ${stimulationArtifactPostRemovalTimeSecs};
+    stimulationArtifactParams.stimTTL = ${stimTTL};
+    stimulationArtifactParams.eventsDir = fullfile([filePath, '/Experiment', sprintf('-%d', expIds), '/CSC_events']);
+
     maxNumCompThreads($maxThreads);
     if strcmp('${mode}', 'spikeSorting')
         disp("run spike sorting");
-        batch_spikeSorting($SGE_TASK_ID, $total_tasks, expIds, filePath, skipExist, runRemovePLI, runCAR, runSpikeReject);
+        batch_spikeSorting($SGE_TASK_ID, $total_tasks, expIds, filePath, skipExist, runRemovePLI, runCAR, runSpikeReject, runStimulationArtifactRemoval, stimulationArtifactParams);
     elseif strcmp('${mode}', 'extractLFP')
         disp("run extract LFP");
         batch_extractLFP($SGE_TASK_ID, $total_tasks, expIds, filePath, skipExist);

--- a/scripts/run_spikeSorting.m
+++ b/scripts/run_spikeSorting.m
@@ -40,6 +40,7 @@ stimulationArtifactParams = struct;
 stimulationArtifactParams.preRemovalTimeSecs = 0.05; % How much time before each stimulation to remove data from (in secs)
 stimulationArtifactParams.postRemovalTimeSecs = 0.3; % How much time after each stimulation to remove data from (in secs)
 stimulationArtifactParams.stimTTL = 1; % TTL value that corresponds to a stimulation
+stimulationArtifactParams.testStimTTL = 32; % TTL value that corresponds to a test stimulation
 stimulationArtifactParams.eventsDir = fullfile([filePath, '/Experiment', sprintf('-%d', expIds), '/CSC_events']);
 
 maxNumCompThreads(numParallelJobs);

--- a/scripts/run_spikeSorting.m
+++ b/scripts/run_spikeSorting.m
@@ -5,11 +5,11 @@ clear
 scriptDir = fileparts(mfilename('fullpath'));
 addpath(genpath(fileparts(scriptDir)));
 
-% expName = 'MovieParadigm';
-expName = 'ABCD';
+ expName = 'MovieParadigm';
+%expName = 'Screening';
 
-patient_id = 579;
-expIds = [3];
+patient_id = 585;
+expIds = [9];
 
 % On Mac studio with 10 cores and 64 GB memory:
 % max 4 tasks for movie paradigm (with sleep data)
@@ -34,5 +34,13 @@ runRemovePLI = false;
 runRejectSpike = false;
 
 
+% Stimulation artifact removal
+runStimulationArtifactRemoval = true;
+stimulationArtifactParams = struct;
+stimulationArtifactParams.preRemovalTimeSecs = 0.05; % How much time before each stimulation to remove data from (in secs)
+stimulationArtifactParams.postRemovalTimeSecs = 0.3; % How much time after each stimulation to remove data from (in secs)
+stimulationArtifactParams.stimTTL = 1; % TTL value that corresponds to a stimulation
+stimulationArtifactParams.eventsDir = fullfile([filePath, '/Experiment', sprintf('-%d', expIds), '/CSC_events']);
+
 maxNumCompThreads(numParallelJobs);
-batch_spikeSorting(1, 1, expIds, filePath, skipExist, runRemovePLI, runCAR, runRejectSpike);
+batch_spikeSorting(1, 1, expIds, filePath, skipExist, runRemovePLI, runCAR, runRejectSpike, runStimulationArtifactRemoval, stimulationArtifactParams);

--- a/scripts/run_spikeSorting.m
+++ b/scripts/run_spikeSorting.m
@@ -42,6 +42,7 @@ stimulationArtifactParams.preRemovalTimeSecs = 0.05; % How much time before each
 stimulationArtifactParams.postRemovalTimeSecs = 0.3; % How much time after each stimulation to remove data from (in secs)
 stimulationArtifactParams.stimTTL = 1; % TTL value that corresponds to a stimulation
 stimulationArtifactParams.testStimTTL = 32; % TTL value that corresponds to a test stimulation
+stimulationArtifactParams.saveRemovedSignalSegments = 2; % Will save the artifact-removed signal of up to this number of segments. Set to 0 for no artifact-removed outputs
 
 if (runStimulationArtifactRemoval && isempty(stimulationArtifactParams.stimulationExps))
     stimulationArtifactParams.stimulationExps = expIds;

--- a/scripts/run_spikeSorting.m
+++ b/scripts/run_spikeSorting.m
@@ -37,11 +37,23 @@ runRejectSpike = false;
 % Stimulation artifact removal
 runStimulationArtifactRemoval = true;
 stimulationArtifactParams = struct;
+stimulationArtifactParams.stimulationExps = [9]; % list of stimulation experiments to remove artifacts from (leave empty to remove from all exps)
 stimulationArtifactParams.preRemovalTimeSecs = 0.05; % How much time before each stimulation to remove data from (in secs)
 stimulationArtifactParams.postRemovalTimeSecs = 0.3; % How much time after each stimulation to remove data from (in secs)
 stimulationArtifactParams.stimTTL = 1; % TTL value that corresponds to a stimulation
 stimulationArtifactParams.testStimTTL = 32; % TTL value that corresponds to a test stimulation
-stimulationArtifactParams.eventsDir = fullfile([filePath, '/Experiment', sprintf('-%d', expIds), '/CSC_events']);
+
+if (runStimulationArtifactRemoval && isempty(stimulationArtifactParams.stimulationExps))
+    stimulationArtifactParams.stimulationExps = expIds;
+end
+stimulationArtifactParams.eventsDirs = {};
+
+for stimulationExpIdx =  1:length(stimulationArtifactParams.stimulationExps)
+    stimulationExpId = stimulationArtifactParams.stimulationExps(stimulationExpIdx);
+    stimExpEventsDir = fullfile([filePath, '/Experiment', sprintf('-%d', stimulationExpId), '/CSC_events']);
+    stimulationArtifactParams.eventsDirs{1, stimulationExpIdx} = stimExpEventsDir;
+end
+
 
 maxNumCompThreads(numParallelJobs);
 batch_spikeSorting(1, 1, expIds, filePath, skipExist, runRemovePLI, runCAR, runRejectSpike, runStimulationArtifactRemoval, stimulationArtifactParams);

--- a/src/spikeSort/getDetectionThresh.m
+++ b/src/spikeSort/getDetectionThresh.m
@@ -1,4 +1,4 @@
-function [spikeThresh, param] = getDetectionThresh(channelFiles, runRemovePLI)
+function [spikeThresh, param] = getDetectionThresh(channelFiles, runRemovePLI, runStimulationArtifactRemoval, stimulationArtifactParams, timestampFiles)
 % Does the first few steps of spike detection to find the threshold. This
 % allows for using the same threshold across multiple sessions. Returns
 % thr, as well as a struct with other variables created so that these steps
@@ -6,6 +6,9 @@ function [spikeThresh, param] = getDetectionThresh(channelFiles, runRemovePLI)
 
     if nargin < 2
         runRemovePLI = false;
+    end
+    if nargin < 3
+        runStimulationArtifactRemoval = false;
     end
 
     param = set_parameters();
@@ -25,6 +28,13 @@ function [spikeThresh, param] = getDetectionThresh(channelFiles, runRemovePLI)
         % assume same sampling interval across channels.
         fprintf("getDetectionThresh: sampling frequency: %d\n", 1/samplingInterval)
         param.sr = 1/samplingInterval;
+        
+        if runStimulationArtifactRemoval
+            [timestamps, ~] = readTimestamps(timestampFiles{i});
+            stimRemovedSignal = removeStimulationArtifacts(signal, timestamps, stimulationArtifactParams);
+            x = stimRemovedSignal;
+        end
+
 
         [~, ~, noise_std_detect(i), noise_std_sorted(i), thr(i), thrmax(i)] = highPassFilter(x, param);
         x = [];

--- a/src/spikeSort/getDetectionThresh.m
+++ b/src/spikeSort/getDetectionThresh.m
@@ -24,6 +24,7 @@ function [spikeThresh, param] = getDetectionThresh(channelFiles, runRemovePLI, r
             warning("getDetectionThresh: file not exist: %s", channelFiles{i})
             continue
         end
+        currentExpID = getExperimentIDFromPath(channelFiles{i});
         [x, samplingInterval] = readCSC(channelFiles{i}, runRemovePLI);
         % assume same sampling interval across channels.
         fprintf("getDetectionThresh: sampling frequency: %d\n", 1/samplingInterval)
@@ -31,7 +32,7 @@ function [spikeThresh, param] = getDetectionThresh(channelFiles, runRemovePLI, r
         
         if runStimulationArtifactRemoval
             [timestamps, ~] = readTimestamps(timestampFiles{i});
-            stimRemovedSignal = removeStimulationArtifacts(signal, timestamps, stimulationArtifactParams);
+            stimRemovedSignal = removeStimulationArtifacts(x, timestamps, stimulationArtifactParams, currentExpID);
             x = stimRemovedSignal;
         end
 

--- a/src/spikeSort/spikeDetection.m
+++ b/src/spikeSort/spikeDetection.m
@@ -34,6 +34,7 @@ outputFiles = cell(1, size(cscFiles, 1));
 
 parfor i = 1:size(cscFiles, 1)
     channelFiles = cscFiles(i,:);
+    
 
     if all(cellfun(@(x)~exist(x, "file"), cscFiles(i, :)))
         warning('csc file not exist %s\n', cscFiles{i, :});
@@ -71,8 +72,8 @@ parfor i = 1:size(cscFiles, 1)
     ExpNameId = cell(nSegments, 1);
     % spikeTimestamps = cell(nSegments, 1);
     duration = 0;
-
-    [outputStruct, param] = getDetectionThresh(channelFiles, runRemovePLI);
+    
+    [outputStruct, param] = getDetectionThresh(channelFiles, runRemovePLI, runStimulationArtifactRemoval, stimulationArtifactParams, timestampFiles);
     timestampsStart = NaN;
     for j = 1: nSegments
         if ~exist(channelFiles{j}, "file")
@@ -98,9 +99,10 @@ parfor i = 1:size(cscFiles, 1)
 
         % Perform stimulus artifact removal
         if runStimulationArtifactRemoval
+            currentExpID = getExperimentIDFromPath(channelFiles{j});
             [~, current_micro_fname] = fileparts(cscFiles{i, j});
             fprintf("Beginning artifact removal for: %s\n", current_micro_fname);
-            stimRemovedSignal = removeStimulationArtifacts(signal, timestamps, stimulationArtifactParams);
+            stimRemovedSignal = removeStimulationArtifacts(signal, timestamps, stimulationArtifactParams, currentExpID);
             signal = stimRemovedSignal;
             if j <= 2
                 stimStruct = struct("stimRemovedSignal", stimRemovedSignal);

--- a/src/spikeSort/spikeDetection.m
+++ b/src/spikeSort/spikeDetection.m
@@ -47,7 +47,7 @@ if runStimulationArtifactRemoval
 
     end
 
-    stimArtifactStartTimestamps = fullEventsTimestamps(fullEventsTTLs == stimulationArtifactParams.stimTTL);
+    stimArtifactStartTimestamps = fullEventsTimestamps(fullEventsTTLs == stimulationArtifactParams.stimTTL | fullEventsTTLs == stimulationArtifactParams.testStimTTL);
     stimulationArtifactParams.stimArtifactEndTimestamps = stimArtifactStartTimestamps + stimulationArtifactParams.postRemovalTimeSecs;
     stimulationArtifactParams.stimArtifactStartTimestamps = stimArtifactStartTimestamps - stimulationArtifactParams.preRemovalTimeSecs;
 end

--- a/src/spikeSort/spikeDetection.m
+++ b/src/spikeSort/spikeDetection.m
@@ -104,11 +104,13 @@ parfor i = 1:size(cscFiles, 1)
             fprintf("Beginning artifact removal for: %s\n", current_micro_fname);
             stimRemovedSignal = removeStimulationArtifacts(signal, timestamps, stimulationArtifactParams, currentExpID);
             signal = stimRemovedSignal;
-            if j <= 2
+            if j <= stimulationArtifactParams.saveRemovedSignalSegments
                 stimStruct = struct("stimRemovedSignal", stimRemovedSignal);
                 %stimStruct.startTimestamps = stimulationArtifactParams.stimArtifactStartTimestamps;
                 %stimStruct.endTimestamps = stimulationArtifactParams.stimArtifactEndTimestamps;
-                stimRemovedSignalFilename = fullfile(outputPath, ['stim_removed_signal_', current_micro_fname, '.mat']);
+                stimRemovedOutputDir = [outputPath, '/stim_removed_exp-',num2str(currentExpID),'/'];
+                if ~exist(stimRemovedOutputDir,'dir'); mkdir(stimRemovedOutputDir); end
+                stimRemovedSignalFilename = fullfile(stimRemovedOutputDir, ['stim_removed_signal_exp-', num2str(currentExpID), '_', current_micro_fname, '.mat']);
                 fprintf("Saving: %s\n", stimRemovedSignalFilename);
                 save(stimRemovedSignalFilename, "-fromstruct", stimStruct);
                 

--- a/src/spikeSort/spikeDetection.m
+++ b/src/spikeSort/spikeDetection.m
@@ -52,7 +52,7 @@ if runStimulationArtifactRemoval
     stimulationArtifactParams.stimArtifactStartTimestamps = stimArtifactStartTimestamps - stimulationArtifactParams.preRemovalTimeSecs;
 end
 
-parfor i = size(cscFiles, 1)
+parfor i = 1:size(cscFiles, 1)
     channelFiles = cscFiles(i,:);
 
     if all(cellfun(@(x)~exist(x, "file"), cscFiles(i, :)))

--- a/src/spikeSort/spikeDetection.m
+++ b/src/spikeSort/spikeDetection.m
@@ -118,10 +118,20 @@ parfor i = 1:size(cscFiles, 1)
 
         % Perform stimulus artifact removal
         if runStimulationArtifactRemoval
+            [~, current_micro_fname] = fileparts(cscFiles{i, j});
+            fprintf("Beginning artifact removal for: %s\n", current_micro_fname);
             stimRemovedSignal = removeStimulationArtifacts(signal, timestamps, stimulationArtifactParams);
             signal = stimRemovedSignal;
+            if j <= 2
+                stimStruct = struct("stimRemovedSignal", stimRemovedSignal);
+                stimStruct.startTimestamps = stimulationArtifactParams.stimArtifactStartTimestamps;
+                stimStruct.endTimestamps = stimulationArtifactParams.stimArtifactEndTimestamps;
+                stimRemovedSignalFilename = fullfile(outputPath, ['stim_removed_signal_', current_micro_fname, '.mat']);
+                fprintf("Saving: %s\n", stimRemovedSignalFilename);
+                save(stimRemovedSignalFilename, "-fromstruct", stimStruct);
+                
+            end
         end
-
         % duration includes gaps between experiments, which is necessary
         % for spikeHist calculation in getSpikeCodes. This take huge
         % memory.

--- a/src/spikeSort/spikeDetection.m
+++ b/src/spikeSort/spikeDetection.m
@@ -32,26 +32,6 @@ makeOutputPath(cscFiles, outputPath, skipExist);
 nSegments = length(timestampFiles);
 outputFiles = cell(1, size(cscFiles, 1));
 
-% Load start and end timestamps for all stim artifacts if we are doing stim
-% artifact removal
-if runStimulationArtifactRemoval
-    eventsFiles = dir(fullfile([stimulationArtifactParams.eventsDir '/Events*.mat']));
-
-    fullEventsTimestamps = [];
-    fullEventsTTLs = [];
-    for eventIdx = 1:length(eventsFiles)
-        eventsFile = fullfile([eventsFiles(eventIdx).folder '/'  eventsFiles(eventIdx).name]);
-        eventsLoad = load(eventsFile);
-        fullEventsTimestamps = [fullEventsTimestamps eventsLoad.timestamps];
-        fullEventsTTLs = [fullEventsTTLs eventsLoad.TTLs];
-
-    end
-
-    stimArtifactStartTimestamps = fullEventsTimestamps(fullEventsTTLs == stimulationArtifactParams.stimTTL | fullEventsTTLs == stimulationArtifactParams.testStimTTL);
-    stimulationArtifactParams.stimArtifactEndTimestamps = stimArtifactStartTimestamps + stimulationArtifactParams.postRemovalTimeSecs;
-    stimulationArtifactParams.stimArtifactStartTimestamps = stimArtifactStartTimestamps - stimulationArtifactParams.preRemovalTimeSecs;
-end
-
 parfor i = 1:size(cscFiles, 1)
     channelFiles = cscFiles(i,:);
 

--- a/src/spikeSort/spikeDetection.m
+++ b/src/spikeSort/spikeDetection.m
@@ -106,8 +106,8 @@ parfor i = 1:size(cscFiles, 1)
             signal = stimRemovedSignal;
             if j <= 2
                 stimStruct = struct("stimRemovedSignal", stimRemovedSignal);
-                stimStruct.startTimestamps = stimulationArtifactParams.stimArtifactStartTimestamps;
-                stimStruct.endTimestamps = stimulationArtifactParams.stimArtifactEndTimestamps;
+                %stimStruct.startTimestamps = stimulationArtifactParams.stimArtifactStartTimestamps;
+                %stimStruct.endTimestamps = stimulationArtifactParams.stimArtifactEndTimestamps;
                 stimRemovedSignalFilename = fullfile(outputPath, ['stim_removed_signal_', current_micro_fname, '.mat']);
                 fprintf("Saving: %s\n", stimRemovedSignalFilename);
                 save(stimRemovedSignalFilename, "-fromstruct", stimStruct);

--- a/src/utils/getExperimentIDFromPath.m
+++ b/src/utils/getExperimentIDFromPath.m
@@ -1,0 +1,8 @@
+function experimentID = getExperimentIDFromPath(filepath)
+    try
+        experimentID = str2num(cell2mat(regexp( filepath, '(?<=Experiment-)\d+', 'match')));
+    catch
+        experimentID = -1;
+    end
+end
+

--- a/src/utils/removeStimulationArtifacts.m
+++ b/src/utils/removeStimulationArtifacts.m
@@ -1,0 +1,30 @@
+function stimRemoveSignal = removeStimulationArtifacts(originalSignal, originalTimestamps, stimulationArtifactParams)
+    stimRemoveSignal = originalSignal;
+
+    timeDiffEps = 20*1e-6; % CSC times should be shifted ~+16micro from TTL times, make check 20 to be safe
+    stimStartTSMatch = arrayfun(@(x) findTimestampIndex(x, originalTimestamps, timeDiffEps, 1, length(originalTimestamps)), stimulationArtifactParams.stimArtifactStartTimestamps);
+    stimEndTSMatch = arrayfun(@(x) findTimestampIndex(x, originalTimestamps, timeDiffEps, 1, length(originalTimestamps)), stimulationArtifactParams.stimArtifactEndTimestamps);
+    numStimMatches = length(stimStartTSMatch);
+    for stimMatchIndex = 1:numStimMatches
+        stimStartIndex = stimStartTSMatch(stimMatchIndex);
+        stimEndIndex = stimEndTSMatch(stimMatchIndex);
+        if stimStartIndex <= 0 && stimEndIndex <= 0
+            continue
+        elseif stimStartIndex <= 0
+            stimStartIndex = 1;
+        elseif stimEndIndex <= 0
+            stimEndIndex = length(timestamps);
+        end
+
+        timestampEndpoints = [originalTimestamps(stimStartIndex) originalTimestamps(stimEndIndex)];
+        signalEndpoints = [originalSignal(stimStartIndex) originalSignal(stimEndIndex)];
+        timeSlice = originalTimestamps(stimStartIndex:stimEndIndex);
+        interpData = interp1(timestampEndpoints, signalEndpoints, timeSlice);
+        stimRemoveSignal(stimStartIndex:stimEndIndex) = interpData;
+
+    end
+
+
+
+end
+

--- a/src/utils/removeStimulationArtifacts.m
+++ b/src/utils/removeStimulationArtifacts.m
@@ -1,10 +1,23 @@
-function stimRemoveSignal = removeStimulationArtifacts(originalSignal, originalTimestamps, stimulationArtifactParams)
+function stimRemoveSignal = removeStimulationArtifacts(originalSignal, originalTimestamps, stimulationArtifactParams, currentExpID)
     stimRemoveSignal = originalSignal;
 
+    % Check if the current experiment is a removal-targeted experiment and
+    % get the corresponding eventsDir if so
+    experimentIndex = 1;
+    if nargin > 3
+        experimentIndex = find(stimulationArtifactParams.stimulationExps == currentExpID);
+    end
+    % If no experiment index found, tis is not a removal-targeted
+    % experiment, so just return the original signal
+    if isempty(experimentIndex)
+        return;
+    end
 
+    eventsDir = stimulationArtifactParams.eventsDirs{1, experimentIndex(1)};
+    
     % Load start and end timestamps for all stim artifacts if we are doing stim
     % artifact removal
-    eventsFiles = dir(fullfile([stimulationArtifactParams.eventsDir '/Events*.mat']));
+    eventsFiles = dir(fullfile([eventsDir '/Events*.mat']));
 
     fullEventsTimestamps = [];
     fullEventsTTLs = [];

--- a/src/utils/removeStimulationArtifacts.m
+++ b/src/utils/removeStimulationArtifacts.m
@@ -1,7 +1,8 @@
 function stimRemoveSignal = removeStimulationArtifacts(originalSignal, originalTimestamps, stimulationArtifactParams)
     stimRemoveSignal = originalSignal;
 
-    timeDiffEps = 20*1e-6; % CSC times should be shifted ~+16micro from TTL times, make check 20 to be safe
+    %timeDiffEps = 20*1e-6; % CSC times should be shifted ~+16micro from TTL times, make check 20 to be safe
+    timeDiffEps = mode(diff(originalTimestamps)) / 2 + (4e-6);
     stimStartTSMatch = arrayfun(@(x) findTimestampIndex(x, originalTimestamps, timeDiffEps, 1, length(originalTimestamps)), stimulationArtifactParams.stimArtifactStartTimestamps);
     stimEndTSMatch = arrayfun(@(x) findTimestampIndex(x, originalTimestamps, timeDiffEps, 1, length(originalTimestamps)), stimulationArtifactParams.stimArtifactEndTimestamps);
     numStimMatches = length(stimStartTSMatch);
@@ -13,7 +14,7 @@ function stimRemoveSignal = removeStimulationArtifacts(originalSignal, originalT
         elseif stimStartIndex <= 0
             stimStartIndex = 1;
         elseif stimEndIndex <= 0
-            stimEndIndex = length(timestamps);
+            stimEndIndex = length(originalTimestamps);
         end
 
         timestampEndpoints = [originalTimestamps(stimStartIndex) originalTimestamps(stimEndIndex)];

--- a/src/utils/timestamps/findTimestampIndex.m
+++ b/src/utils/timestamps/findTimestampIndex.m
@@ -1,0 +1,41 @@
+function timestampIndex = findTimestampIndex(timestampVal,timestampArr, timestampDiffEps, startIdx, endIdx)
+    if isempty(timestampArr)
+        timestampIndex = -3;
+        return;
+    end
+    if nargin < 4
+        startIdx = 1;
+    end
+    if nargin < 5
+        endIdx = length(timestampArr);
+    end
+    if(timestampVal < timestampArr(startIdx)) && (timestampVal - timestampArr(startIdx)) < (-1 * timestampDiffEps)
+         timestampIndex = -1;
+         return;
+     end
+     if(timestampVal > timestampArr(endIdx))
+         timestampIndex = -2;
+         return;
+     end
+
+    if (timestampArr(startIdx) - timestampVal) >= 0 && (timestampArr(startIdx) - timestampVal) <= timestampDiffEps
+        timestampIndex = startIdx;
+        return;
+    end
+    if (timestampArr(endIdx) - timestampVal) >= 0 && (timestampArr(endIdx) - timestampVal) <=  timestampDiffEps
+        timestampIndex = endIdx;
+        return;
+    end   
+    
+    midpt = floor((startIdx + endIdx) / 2);
+    if (timestampArr(midpt) - timestampVal) <  timestampDiffEps
+        timestampIndex = findTimestampIndex(timestampVal,timestampArr, timestampDiffEps, midpt, endIdx);
+        return;
+    else
+        timestampIndex = findTimestampIndex(timestampVal,timestampArr, timestampDiffEps, startIdx, midpt);
+        return;
+    end
+
+
+end
+

--- a/src/utils/timestamps/findTimestampIndex.m
+++ b/src/utils/timestamps/findTimestampIndex.m
@@ -1,4 +1,5 @@
 function timestampIndex = findTimestampIndex(timestampVal,timestampArr, timestampDiffEps, startIdx, endIdx)
+    
     if isempty(timestampArr)
         timestampIndex = -3;
         return;
@@ -27,6 +28,11 @@ function timestampIndex = findTimestampIndex(timestampVal,timestampArr, timestam
         return;
     end   
     
+    if (endIdx - startIdx) < 2
+        timestampIndex = endIdx;
+        return;
+    end
+
     midpt = floor((startIdx + endIdx) / 2);
     if (timestampArr(midpt) - timestampVal) <  timestampDiffEps
         timestampIndex = findTimestampIndex(timestampVal,timestampArr, timestampDiffEps, midpt, endIdx);


### PR DESCRIPTION
This PR allows users to specify a stimulation TTL marker alongside a [before, after] time interval (in seconds). These parameters are used to remove neural signal during the specified time interval on each TTL marker and interpolating the segments before and after, essentially removing artifacts caused by stimulation.

Note that this artifact removal is done both during threshold calculation as well as during the actual spike sorting process.

Tested on Ubuntu 22.04, Windows 11, and MacOS